### PR TITLE
Fix comparison function for multi-matches

### DIFF
--- a/wordel.el
+++ b/wordel.el
@@ -374,16 +374,21 @@ If PROPS are non-nil, they are used in place of default values."
 
 (defun wordel--comparison (guess subject)
   "Return propertized GUESS character list compared against SUBJECT."
-  (cl-loop with guesses =  (split-string guess "" 'omit-nulls)
-           with matches = nil
-           for i from 0
-           for g in guesses
-           for match = (setf (alist-get g matches nil t #'equal)
-                             (string-match-p g subject (1+ (alist-get g matches -1 nil #'equal))))
-           collect (propertize g 'hint (if (not match) 'wordel-guessed
-                                         (if (eq (string-to-char g) (aref subject i))
-                                             'wordel-correct
-                                           'wordel-almost)))))
+  (cl-loop with non-matches = (cl-loop for s across subject
+                                       for g across guess
+                                       unless (= g s)
+                                       collect s)
+           for s across subject
+           for g across guess
+           collect (propertize (char-to-string g)
+                               'hint
+                               (if (= g s)
+                                   'wordel-correct
+                                 (if-let ((i (cl-position g non-matches)))
+                                     (progn
+                                       (pop (nthcdr i non-matches))
+                                       'wordel-almost)
+                                   'wordel-guessed)))))
 
 (defun wordel--rules ()
   "Return the rules string."


### PR DESCRIPTION
As discussed in #12 the current fix for `wordel--comparison` is still not correct. It fails 4 of the test cases I collected here:

```
#+name: Testcases
| guess | answer | score      | type   |
|-------+--------+------------+--------|
| skill | brave  | ⬜⬜⬜⬜⬜ | none   |
| crane | crane  | 🟩🟩🟩🟩🟩 | solved |
| crank | crane  | 🟩🟩🟩🟩⬜ | almost |
| skull | rebus  | 🟨⬜🟨⬜⬜ | normal |
| adobe | adage  | 🟩🟩⬜⬜🟩 | normal |
| quiet | serif  | ⬜⬜🟨🟨⬜ | normal |
| radix | raise  | 🟩🟩⬜🟨⬜ | normal |
| canon | xenon  | ⬜⬜🟩🟩🟩 | multi  |
| kebab | abbey  | ⬜🟨🟩🟨🟨 | multi  |
| abbey | kebab  | 🟨🟨🟩🟨⬜ | multi  |
| babes | abbey  | 🟨🟨🟩🟩⬜ | multi  |
| abyss | abbey  | 🟩🟩🟨⬜⬜ | multi  |
| algae | abbey  | 🟩⬜⬜⬜🟨 | multi  |
| keeps | abbey  | ⬜🟨⬜⬜⬜ | multi  |
| abate | abbey  | 🟩🟩⬜⬜🟨 | multi  |
| train | xenon  | ⬜⬜⬜⬜🟩 | multi  |
| allay | telos  | ⬜⬜🟩⬜⬜ | multi  |
| allyl | telos  | ⬜⬜🟩⬜⬜ | multi  |
| allee | telos  | ⬜⬜🟩🟨⬜ | multi  |
| crane | crank  | 🟩🟩🟩🟩⬜ | almost |
| rebus | skull  | ⬜⬜⬜🟨🟨 | normal |
| adage | adobe  | 🟩🟩⬜⬜🟩 | normal |
| serif | quiet  | ⬜🟨⬜🟨⬜ | normal |
| raise | radix  | 🟩🟩🟨⬜⬜ | normal |
| xenon | canon  | ⬜⬜🟩🟩🟩 | multi  |
| abbey | babes  | 🟨🟨🟩🟩⬜ | multi  |
| abbey | abyss  | 🟩🟩⬜⬜🟨 | multi  |
| abbey | algae  | 🟩⬜⬜🟨⬜ | multi  |
| abbey | keeps  | ⬜⬜⬜🟨⬜ | multi  |
| abbey | abate  | 🟩🟩⬜🟨⬜ | multi  |
| xenon | train  | ⬜⬜⬜⬜🟩 | multi  |
| telos | allay  | ⬜⬜🟩⬜⬜ | multi  |
| telos | allyl  | ⬜⬜🟩⬜⬜ | multi  |
| telos | allee  | ⬜🟨🟩⬜⬜ | multi  |

#+begin_src elisp :var cases=Testcases :results output
(defun compare-guess-subject (guess subject)
  (cl-loop
   for p in (wordel--comparison guess subject)
   concat (case (cadr (text-properties-at 0 p))
            (wordel-correct "🟩")
            (wordel-almost "🟨")
            (wordel-guessed "⬜"))))

(cl-loop
 for i from 0
 for testcase in cases do
 (seq-let (guess subject expected type) testcase
   (eval
    `(ert-deftest ,(intern (format "compare-%02d-%s-%s" i guess subject)) () :tags '(wordle ,type)
       (should (equal (compare-guess-subject ,guess ,subject)
                      ,expected))))))
(ert '(tag wordle))
#+end_src
```

E.g. a guess of `allyl` with a subject of `telos` should return ⬜⬜🟩⬜⬜ but it currently returns ⬜🟨⬜⬜🟨. The proposed implementation fixes all these cases.
